### PR TITLE
Small addition to .gitignore for users of IDEA editors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea/*


### PR DESCRIPTION
This will ignore everything in the `.idea` directory in the root of the repo for users who wish to use IDEA products such as IntelliJ, WebStorm, etc.